### PR TITLE
Bump minimum Rust version to 1.33.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
   test_image:
     docker:
-      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.31.0
+      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:$IMAGE_TAG
         environment:
           <<: *image_config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
 
   test_image:
     docker:
-      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:$IMAGE_TAG
+      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.33.0
         environment:
           <<: *image_config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 
 image_config: &image_config
   IMAGE_NAME: renderdoc-rs-circleci
-  IMAGE_TAG: 1.31.0
+  IMAGE_TAG: 1.33.0
 
 version: 2
 jobs:


### PR DESCRIPTION
### Changed

* Bump minimum stable Rust version to 1.33.0.

Fixes #1.