### PR TITLE
Bump minimum Rust version to 1.51.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ image_config: &image_config
 version: 2
 jobs:
   build:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       <<: *image_config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 
 image_config: &image_config
   IMAGE_NAME: renderdoc-rs-circleci
-  IMAGE_TAG: 1.48.0
+  IMAGE_TAG: 1.51.0
 
 version: 2
 jobs:
@@ -40,7 +40,7 @@ jobs:
 
   test_image:
     docker:
-      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.48.0
+      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.51.0
         environment:
           <<: *image_config
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -10,7 +10,9 @@ FROM cimg/rust:${IMAGE_TAG:-latest}
 
 # Install 'renderdoc' on top of base image
 RUN \\
-    echo 'deb http://ftp.debian.org/debian unstable main contrib non-free' | sudo tee /etc/apt/sources.list.d/unstable.list > /dev/null && \\
+    echo 'deb http://deb.debian.org/debian unstable main contrib non-free' | sudo tee /etc/apt/sources.list.d/unstable.list > /dev/null && \\
+    APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138 && \\
+    APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9 && \\
     sudo apt-get -y update && \\
     sudo apt-get -y install --no-install-recommends -t unstable renderdoc && \\
     sudo apt-get -y clean

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,7 +6,7 @@ cat <<EOF
 # RenderDoc installed from the \`unstable\` Debian repository.
 #
 
-FROM circleci/rust:${IMAGE_TAG:-latest}
+FROM cimg/rust:${IMAGE_TAG:-latest}
 
 # Install 'renderdoc' on top of base image
 RUN \\


### PR DESCRIPTION
### Changed

* Bump minimum Rust version to 1.51.0.
* Switch to supported CircleCI machine image ([upstream docs](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/)).

This should fix the `cargo-features = ["resolver"]` errors currently occurring in CircleCI.