### PR TITLE
Bump minimum supported Rust version to 1.54.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@
 
 image_config: &image_config
   IMAGE_NAME: renderdoc-rs-circleci
-  IMAGE_TAG: 1.51.0
+  IMAGE_TAG: 1.54.0
 
 version: 2
 jobs:
@@ -41,7 +41,7 @@ jobs:
 
   test_image:
     docker:
-      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.51.0
+      - image: $DOCKER_USERNAME/renderdoc-rs-circleci:1.54.0
         environment:
           <<: *image_config
 


### PR DESCRIPTION
### Changed

* Bump minimum supported Rust version to 1.54.0.

This should hopefully resolve the following error building `pollster-0.2.5` in CircleCI:

```
error[E0658]: arbitrary expressions in key-value attributes are unstable
 --> /home/circleci/.cargo/registry/src/github.com-1ecc6299db9ec823/pollster-0.2.5/src/lib.rs:1:10
  |
1 | #![doc = include_str!("../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835> for more information
```

Follow-up to #7.